### PR TITLE
Fix SHA detection to avoid partial matches

### DIFF
--- a/livecheck/utils/string.py
+++ b/livecheck/utils/string.py
@@ -41,9 +41,9 @@ def is_sha(url: str) -> Literal[40, 7, 0]:
     """
     last_part = urlparse(url).path.rsplit('/', 1)[-1] if '/' in url else url
 
-    if re.match(r'^[0-9a-f]{40}', last_part):
+    if re.fullmatch(r'[0-9a-f]{40}', last_part):
         return 40
-    if re.match(r'^[0-9a-f]{7}', last_part):
+    if re.fullmatch(r'[0-9a-f]{7}', last_part):
         return 7
     return 0
 

--- a/tests/utils/test_string.py
+++ b/tests/utils/test_string.py
@@ -272,3 +272,15 @@ def test_is_sha_non_hex_sha() -> None:
     sha = 'zzzzzzz'
     url = f'https://example.com/commit/{sha}'
     assert is_sha(url) == 0
+
+
+def test_is_sha_sha_with_trailing_characters() -> None:
+    sha = 'abcdef1'
+    url = f'https://example.com/commit/{sha}extra'
+    assert is_sha(url) == 0
+
+
+def test_is_sha_full_sha_with_trailing_characters() -> None:
+    sha = 'a' * 40
+    url = f'https://example.com/commit/{sha}extra'
+    assert is_sha(url) == 0


### PR DESCRIPTION
## Summary
- ensure `is_sha` only matches complete SHA strings
- test SHA detection with trailing characters

## Testing
- `PYTHONPATH=$(pwd) pytest tests/utils/test_credentials.py tests/utils/test_misc.py tests/utils/test_requests.py tests/utils/test_string.py -q`
- `PYTHONPATH=$(pwd) pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48e1095a8832eb9f4701f01d745b5