### PR TITLE
feat: add maven build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ action directory there can be several scripts that are executed in order of name
 - `branch` - string- The GitHub branch name to use for commits.
 - `composer_packages` - boolean - Download composer vendor modules.
 - `composer_path` - path - Where is 'composer.json' located (need composer_packages).
+- `maven_packages` - boolean - Download Maven dependencies.
+- `maven_path` - path - Where is 'pom.xml' located (need maven_packages).
 - `development` - bool - Include development packages.
 - `gomodule_packages` - boolean - Download go vendor modules.
 - `gomodule_path` - path - Where is 'go.mod' located (need gomodule_packages).

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -66,6 +66,11 @@ from .special.gomodule import (
     update_gomodule_ebuild,
 )
 from .special.jetbrains import get_latest_jetbrains_package, is_jetbrains, update_jetbrains_ebuild
+from .special.maven import (
+    check_maven_requirements,
+    remove_maven_url,
+    update_maven_ebuild,
+)
 from .special.metacpan import (
     METACPAN_METADATA,
     get_latest_metacpan_metadata,
@@ -502,6 +507,7 @@ def do_main(  # noqa: C901, PLR0912, PLR0915
             if ((  # noqa: PLR0916
                     cp in settings.dotnet_projects and not check_dotnet_requirements())
                     or (cp in settings.composer_packages and not check_composer_requirements())
+                    or (cp in settings.maven_packages and not check_maven_requirements())
                     or (cp in settings.yarn_base_packages and not check_yarn_requirements())
                     or (cp in settings.nodejs_packages and not check_nodejs_requirements())
                     or (cp in settings.gomodule_packages and not check_gomodule_requirements())):
@@ -552,6 +558,8 @@ def do_main(  # noqa: C901, PLR0912, PLR0915
                 content = remove_nodejs_url(content)
             if cp in settings.composer_packages:
                 content = remove_composer_url(content)
+            if cp in settings.maven_packages:
+                content = remove_maven_url(content)
             if old_content != content:
                 Path(new_filename).write_text(content, encoding='utf-8')
             if not digest_ebuild(new_filename):
@@ -576,6 +584,8 @@ def do_main(  # noqa: C901, PLR0912, PLR0915
                 update_gomodule_ebuild(new_filename, settings.gomodule_path[cp], fetchlist)
             if cp in settings.composer_packages:
                 update_composer_ebuild(new_filename, settings.composer_path[cp], fetchlist)
+            if cp in settings.maven_packages:
+                update_maven_ebuild(new_filename, settings.maven_path[cp], fetchlist)
             # Restore original ebuild content
             if old_content != content:
                 Path(new_filename).write_text(old_content, encoding='utf-8')

--- a/livecheck/settings.py
+++ b/livecheck/settings.py
@@ -61,6 +61,8 @@ class LivecheckSettings:
     development: dict[str, bool] = field(default_factory=dict)
     composer_packages: dict[str, bool] = field(default_factory=dict)
     composer_path: dict[str, str] = field(default_factory=dict)
+    maven_packages: dict[str, bool] = field(default_factory=dict)
+    maven_path: dict[str, str] = field(default_factory=dict)
     regex_version: dict[str, tuple[str, str]] = field(default_factory=dict)
     restrict_version: dict[str, str] = field(default_factory=dict)
     sync_version: dict[str, str] = field(default_factory=dict)
@@ -116,6 +118,8 @@ def gather_settings(search_dir: Path) -> LivecheckSettings:  # noqa: C901, PLR09
     development: dict[str, bool] = {}
     composer_packages: dict[str, bool] = {}
     composer_path: dict[str, str] = {}
+    maven_packages: dict[str, bool] = {}
+    maven_path: dict[str, str] = {}
     regex_version: dict[str, tuple[str, str]] = {}
     restrict_version: dict[str, str] = {}
     sync_version: dict[str, str] = {}
@@ -223,6 +227,13 @@ def gather_settings(search_dir: Path) -> LivecheckSettings:  # noqa: C901, PLR09
                     check_instance(settings_parsed['composer_path'], 'composer_path', 'string',
                                    path)
                     composer_path[catpkg] = settings_parsed['composer_path']
+            if 'maven' in settings_parsed:
+                check_instance(settings_parsed['maven'], 'maven', 'bool', path)
+                maven_packages[catpkg] = settings_parsed['maven']
+                maven_path[catpkg] = ''
+                if settings_parsed.get('maven_path'):
+                    check_instance(settings_parsed['maven_path'], 'maven_path', 'string', path)
+                    maven_path[catpkg] = settings_parsed['maven_path']
             if 'pattern_version' in settings_parsed or 'replace_version' in settings_parsed:
                 if 'pattern_version' not in settings_parsed:
                     log.error('No "pattern_version" in %s.', path)
@@ -253,8 +264,9 @@ def gather_settings(search_dir: Path) -> LivecheckSettings:  # noqa: C901, PLR09
                              type_packages, no_auto_update, sha_sources, transformations,
                              yarn_base_packages, yarn_packages, jetbrains_packages, keep_old,
                              gomodule_packages, gomodule_path, nodejs_packages, nodejs_path,
-                             development, composer_packages, composer_path, regex_version,
-                             restrict_version, sync_version, stable_version)
+                             development, composer_packages, composer_path, maven_packages,
+                             maven_path, regex_version, restrict_version, sync_version,
+                             stable_version)
 
 
 def check_instance(

--- a/livecheck/special/maven.py
+++ b/livecheck/special/maven.py
@@ -1,0 +1,48 @@
+"""Maven functions."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import logging
+import subprocess as sp
+
+from livecheck.utils import check_program
+
+from .utils import build_compress, remove_url_ebuild, search_ebuild
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ('check_maven_requirements', 'remove_maven_url', 'update_maven_ebuild')
+
+log = logging.getLogger(__name__)
+
+
+def remove_maven_url(ebuild_content: str) -> str:
+    """Remove the URL for the Maven dependency tarball from the ebuild content."""
+    return remove_url_ebuild(ebuild_content, '-maven-deps.tar.xz')
+
+
+def update_maven_ebuild(ebuild: str, path: str | None,
+                        fetchlist: Mapping[str, tuple[str, ...]]) -> None:
+    """Update a Maven package ebuild."""
+    maven_path, temp_dir = search_ebuild(ebuild, 'pom.xml', path)
+    if not maven_path:
+        return
+
+    try:
+        sp.run(('mvn', '--batch-mode', '-Dmaven.repo.local=m2', 'dependency:go-offline'),
+               cwd=maven_path,
+               check=True)
+    except sp.CalledProcessError:
+        log.exception("Error running 'mvn'.")
+        return
+
+    build_compress(temp_dir, maven_path, 'm2', '-maven-deps.tar.xz', fetchlist)
+
+
+def check_maven_requirements() -> bool:
+    """Check if Maven is installed."""
+    if not check_program('mvn', ['--version']):
+        log.error('mvn is not installed')
+        return False
+    return True

--- a/tests/special/test_maven.py
+++ b/tests/special/test_maven.py
@@ -1,0 +1,93 @@
+"""Tests for Maven helpers."""
+# ruff: noqa: S108
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from livecheck.special.maven import (
+    check_maven_requirements,
+    remove_maven_url,
+    update_maven_ebuild,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def test_remove_maven_url_calls_remove_url_ebuild(mocker: MockerFixture) -> None:
+    mock_remove_url_ebuild = mocker.patch('livecheck.special.maven.remove_url_ebuild')
+    mock_remove_url_ebuild.return_value = 'result'
+    ebuild_content = 'SOME CONTENT'
+    result = remove_maven_url(ebuild_content)
+    mock_remove_url_ebuild.assert_called_once_with(ebuild_content, '-maven-deps.tar.xz')
+    assert result == 'result'
+
+
+def test_remove_maven_url_returns_expected_value(mocker: MockerFixture) -> None:
+    expected = 'cleaned content'
+    mocker.patch('livecheck.special.maven.remove_url_ebuild', return_value=expected)
+    assert remove_maven_url('dummy') == expected
+
+
+def test_update_maven_ebuild_no_maven_path(mocker: MockerFixture) -> None:
+    mock_search_ebuild = mocker.patch('livecheck.special.maven.search_ebuild')
+    mock_search_ebuild.return_value = (None, None)
+    mock_sp_run = mocker.patch('livecheck.special.maven.sp.run')
+    mock_build_compress = mocker.patch('livecheck.special.maven.build_compress')
+
+    update_maven_ebuild('ebuild', 'path', {})
+    mock_sp_run.assert_not_called()
+    mock_build_compress.assert_not_called()
+
+
+def test_update_maven_ebuild_success(mocker: MockerFixture) -> None:
+    mock_search_ebuild = mocker.patch('livecheck.special.maven.search_ebuild')
+    maven_path = '/tmp/maven'
+    temp_dir = '/tmp/temp'
+    mock_search_ebuild.return_value = (maven_path, temp_dir)
+    mock_sp_run = mocker.patch('livecheck.special.maven.sp.run')
+    mock_build_compress = mocker.patch('livecheck.special.maven.build_compress')
+
+    fetchlist = {'foo': ('bar',)}
+    update_maven_ebuild('ebuild', 'path', fetchlist)
+
+    mock_sp_run.assert_called_once_with(
+        ('mvn', '--batch-mode', '-Dmaven.repo.local=m2', 'dependency:go-offline'),
+        cwd=maven_path,
+        check=True,
+    )
+    mock_build_compress.assert_called_once_with(temp_dir, maven_path, 'm2',
+                                               '-maven-deps.tar.xz', fetchlist)
+
+
+def test_update_maven_ebuild_sp_run_raises(mocker: MockerFixture) -> None:
+    mock_search_ebuild = mocker.patch('livecheck.special.maven.search_ebuild')
+    maven_path = '/tmp/maven'
+    temp_dir = '/tmp/temp'
+    mock_search_ebuild.return_value = (maven_path, temp_dir)
+    mock_sp_run = mocker.patch('livecheck.special.maven.sp.run')
+    mock_sp_run.side_effect = __import__('subprocess').CalledProcessError(1, 'mvn')
+    mock_build_compress = mocker.patch('livecheck.special.maven.build_compress')
+    mock_log = mocker.patch('livecheck.special.maven.log')
+
+    update_maven_ebuild('ebuild', 'path', {})
+
+    mock_sp_run.assert_called_once()
+    mock_build_compress.assert_not_called()
+    assert mock_log.exception.called
+
+
+def test_check_maven_requirements_returns_true_when_installed(mocker: MockerFixture) -> None:
+    mock_check_program = mocker.patch('livecheck.special.maven.check_program', return_value=True)
+    mock_log = mocker.patch('livecheck.special.maven.log')
+    assert check_maven_requirements() is True
+    mock_check_program.assert_called_once_with('mvn', ['--version'])
+    mock_log.error.assert_not_called()
+
+
+def test_check_maven_requirements_returns_false_when_not_installed(mocker: MockerFixture) -> None:
+    mock_check_program = mocker.patch('livecheck.special.maven.check_program', return_value=False)
+    mock_log = mocker.patch('livecheck.special.maven.log')
+    assert check_maven_requirements() is False
+    mock_check_program.assert_called_once_with('mvn', ['--version'])
+    mock_log.error.assert_called_once_with('mvn is not installed')


### PR DESCRIPTION
## Summary
- add Maven utilities mirroring Composer handling
- extend settings and update logic for Maven packages
- document new Maven options and add tests

## Testing
- `yarn ruff livecheck/special/maven.py livecheck/main.py livecheck/settings.py tests/test_main.py tests/test_settings.py tests/special/test_maven.py`
- `PYTHONPATH=. pytest tests/special/test_maven.py tests/test_settings.py tests/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_68c444b40670832e8694e18f0e807c29