### PR TITLE
Support per-package detection method overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Options:
   -e, --exclude TEXT           Exclude package(s) from updates.
   -g, --git                    Use git and pkgdev to make changes.
   -H, --hook-dir               Run a hook directory scripts with various parameters.
+  -m, --detection-method [tag|version|commit]
+                               Method to detect a new version (tag, version or commit hash).
   -k, --keep-old               Keep old ebuild versions.
   -p, --progress               Enable progress logging.
   -W, --working-dir DIRECTORY  Working directory. Should be a port tree root.
@@ -123,6 +125,7 @@ action directory there can be several scripts that are executed in order of name
 - `gomodule_path` - path - Where is 'go.mod' located (need gomodule_packages).
 - `jetbrains_packages` - boolean - Update internal ID.
 - `keep_old` - boolean - Keep old ebuild versions.
+- `detection_method` - string - Override detection mode for this package (`tag`, `version`, or `commit`).
 - `no_auto_update` - boolean - Do not allow auto-updating of this package.
 - `nodejs_packages` - boolean - Download nodejs node_modules.
 - `nodejs_path` - path - Where is 'package.json' located (need nodejs_packages).

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,6 +6,7 @@ import json
 import operator
 
 from livecheck.settings import (
+    DETECTION_VERSION,
     TYPE_DIRECTORY,
     TYPE_REGEX,
     LivecheckSettings,
@@ -49,6 +50,8 @@ def test_livecheck_settings_defaults() -> None:
     assert isinstance(s.restrict_version, dict)
     assert isinstance(s.sync_version, dict)
     assert isinstance(s.stable_version, dict)
+    assert isinstance(s.detection_methods, dict)
+    assert s.detection_method == DETECTION_VERSION
     assert s.auto_update_flag is False
     assert s.debug_flag is False
     assert s.development_flag is False
@@ -130,6 +133,13 @@ def test_gather_settings_with_transformation_function(tmp_path: Path) -> None:
     assert 'cat/pkg' in result.transformations
     assert callable(result.transformations['cat/pkg'])
     assert result.transformations['cat/pkg']('re3_v1') == '1'
+
+
+def test_gather_settings_with_detection_method(tmp_path: Path) -> None:
+    data = {'detection_method': 'Commit'}
+    make_json_file(tmp_path, 'cat/pkg/livecheck.json', data)
+    result = gather_settings(tmp_path)
+    assert result.detection_methods['cat/pkg'] == 'commit'
 
 
 def test_gather_settings_with_utils_transformation(tmp_path: Path, mocker: MockerFixture,


### PR DESCRIPTION
## Summary
- allow livecheck.json files to declare per-package detection methods that override the CLI default
- propagate the active detection method throughout version resolution so metadata, URLs, and directory fallbacks honor tag/commit preferences
- cover the new settings shape with unit tests and document the configuration key

## Testing
- PYTHONPATH=. pytest tests/test_main.py::test_get_props_detection_method_commit tests/test_main.py::test_get_props_detection_method_commit_no_hash tests/test_main.py::test_get_props_detection_method_tag tests/test_main.py::test_get_props_detection_method_override tests/test_settings.py::test_livecheck_settings_defaults tests/test_settings.py::test_gather_settings_with_detection_method

------
https://chatgpt.com/codex/tasks/task_e_68d06148b068832e8de7d3c30ae93ea9