### PR TITLE
Add configuration flag to choose Node.js package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Options:
   -g, --git                    Use git and pkgdev to make changes.
   -H, --hook-dir               Run a hook directory scripts with various parameters.
   -k, --keep-old               Keep old ebuild versions.
+  -m, --nodejs-manager [npm|yarn|pnpm]
+                               Command to install node_modules when updating Node.js ebuilds.
   -p, --progress               Enable progress logging.
   -W, --working-dir DIRECTORY  Working directory. Should be a port tree root.
   --help                       Show this message and exit.
@@ -126,6 +128,9 @@ action directory there can be several scripts that are executed in order of name
 - `no_auto_update` - boolean - Do not allow auto-updating of this package.
 - `nodejs_packages` - boolean - Download nodejs node_modules.
 - `nodejs_path` - path - Where is 'package.json' located (need nodejs_packages).
+  Use the `--nodejs-manager` option to select npm (default), yarn, or pnpm when fetching
+  dependencies, or pass `nodejs_manager` to `gather_settings` when using livecheck as a
+  library.
 - `sha_source`- string - Url to get the sha value.
 - `stable_version`- string - Regular expression to determine if it is a stable version.
 - `sync_version` - string - Category and ebuild with version to sync.

--- a/livecheck/special/nodejs.py
+++ b/livecheck/special/nodejs.py
@@ -22,28 +22,38 @@ def remove_nodejs_url(ebuild_content: str) -> str:
     return remove_url_ebuild(ebuild_content, '-node_modules.tar.xz')
 
 
+def get_nodejs_install_command(manager: str) -> tuple[str, ...]:
+    """Return the command tuple to install dependencies."""
+    manager_normalized = manager.lower()
+    if manager_normalized == 'yarn':
+        return ('yarn', 'install', '--ignore-scripts', '--non-interactive', '--silent')
+    if manager_normalized == 'pnpm':
+        return ('pnpm', 'install', '--ignore-scripts', '--silent')
+    return ('npm', 'install', '--audit false', '--color false', '--progress false', '--ignore-scripts')
+
+
 def update_nodejs_ebuild(ebuild: str, path: str | None,
-                         fetchlist: Mapping[str, tuple[str, ...]]) -> None:
+                         fetchlist: Mapping[str, tuple[str, ...]],
+                         manager: str = 'npm') -> None:
     """Update a NodeJS-based ebuild."""
     package_path, temp_dir = search_ebuild(ebuild, 'package.json', path)
     if not package_path:
         return
 
     try:
-        sp.run(('npm', 'install', '--audit false', '--color false', '--progress false',
-                '--ignore-scripts'),
-               cwd=package_path,
-               check=True)
+        command = get_nodejs_install_command(manager)
+        sp.run(command, cwd=package_path, check=True)
     except sp.CalledProcessError:
-        logger.exception("Error running 'npm install'.")
+        logger.exception("Error running '%s install'.", manager)
         return
 
     build_compress(temp_dir, package_path, 'node_modules', '-node_modules.tar.xz', fetchlist)
 
 
-def check_nodejs_requirements() -> bool:
-    """Check if npm is installed."""
-    if not check_program('npm', ['--version']):
-        logger.error('npm is not installed')
+def check_nodejs_requirements(manager: str = 'npm') -> bool:
+    """Check if the required package manager is installed."""
+    binary = get_nodejs_install_command(manager)[0]
+    if not check_program(binary, ['--version']):
+        logger.error('%s is not installed', binary)
         return False
     return True

--- a/livecheck/special/nodejs.py
+++ b/livecheck/special/nodejs.py
@@ -24,12 +24,12 @@ def remove_nodejs_url(ebuild_content: str) -> str:
 
 def get_nodejs_install_command(manager: str) -> tuple[str, ...]:
     """Return the command tuple to install dependencies."""
-    manager_normalized = manager.lower()
-    if manager_normalized == 'yarn':
-        return ('yarn', 'install', '--ignore-scripts', '--non-interactive', '--silent')
-    if manager_normalized == 'pnpm':
-        return ('pnpm', 'install', '--ignore-scripts', '--silent')
-    return ('npm', 'install', '--audit false', '--color false', '--progress false', '--ignore-scripts')
+    commands = {
+        'npm': ('npm', 'install', '--audit=false', '--color=false', '--progress=false', '--ignore-scripts'),
+        'yarn': ('yarn', 'install', '--ignore-scripts', '--non-interactive', '--silent'),
+        'pnpm': ('pnpm', 'install', '--ignore-scripts', '--silent'),
+    }
+    return commands.get(manager.lower(), commands['npm'])
 
 
 def update_nodejs_ebuild(ebuild: str, path: str | None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -104,6 +104,7 @@ def mock_settings(mocker: MockerFixture) -> Any:
     settings.sync_version = {}
     settings.type_packages = {}
     settings.yarn_base_packages = set()
+    settings.nodejs_manager_flag = 'npm'
     return settings
 
 
@@ -655,7 +656,8 @@ def test_do_main_nodejs_packages(mocker: MockerFixture, tmp_path: Path,
             top_hash=top_hash,
             url=url)
     mock_update_nodejs_ebuild.assert_called_once_with(
-        f'{search_dir}/{cat}/{pkg}/{pkg}-{last_version}.ebuild', mocker.ANY, {})
+        f'{search_dir}/{cat}/{pkg}/{pkg}-{last_version}.ebuild', mocker.ANY, {},
+        mock_settings.nodejs_manager_flag)
     mock_write.assert_called_once_with('abcdef1', encoding='utf-8')
 
 
@@ -1493,6 +1495,7 @@ def mock_settings2(mocker: MockerFixture) -> Any:
     settings.custom_livechecks = {}
     settings.branches = {}
     settings.restrict_version_process = None
+    settings.nodejs_manager_flag = 'npm'
     return settings
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -55,6 +55,7 @@ def test_livecheck_settings_defaults() -> None:
     assert s.git_flag is False
     assert s.keep_old_flag is False
     assert s.progress_flag is False
+    assert s.nodejs_manager_flag == 'npm'
     assert not s.restrict_version_process
 
 
@@ -116,6 +117,16 @@ def test_gather_settings_basic(tmp_path: Path) -> None:
     assert 'cat/pkg' in result.custom_livechecks
     assert result.custom_livechecks['cat/pkg'] == ('https://example.com', 'v([0-9.]+)')
     assert result.type_packages['cat/pkg'] == TYPE_REGEX
+
+
+def test_gather_settings_sets_nodejs_manager_flag(tmp_path: Path) -> None:
+    result = gather_settings(tmp_path, nodejs_manager='Yarn')
+    assert result.nodejs_manager_flag == 'yarn'
+
+
+def test_gather_settings_invalid_nodejs_manager(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        gather_settings(tmp_path, nodejs_manager='bun')
 
 
 def test_gather_settings_with_transformation_function(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a --nodejs-manager CLI option and settings flag to pick npm, yarn, or pnpm when fetching node_modules
- teach the Node.js helper to invoke the selected package manager and extend unit tests accordingly
- document the new option in the README for both CLI usage and configuration keys
- allow programmatic callers to select and validate the Node.js manager when gathering settings

## Testing
- `PYTHONPATH=. pytest tests/test_settings.py` *(fails: missing optional dependencies 'pytest-mock' fixture provider and 'portage')*

------
https://chatgpt.com/codex/tasks/task_e_68d6868261b4832e85eb3a9585cc5428