### PR TITLE
Add configurable Node.js package manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Options:
   -H, --hook-dir               Run a hook directory scripts with various parameters.
   -k, --keep-old               Keep old ebuild versions.
   -p, --progress               Enable progress logging.
+  --package-manager [npm|pnpm|yarn]
+                               Package manager to use for Node.js packages.
   -W, --working-dir DIRECTORY  Working directory. Should be a port tree root.
   --help                       Show this message and exit.
 ```
@@ -126,6 +128,8 @@ action directory there can be several scripts that are executed in order of name
 - `no_auto_update` - boolean - Do not allow auto-updating of this package.
 - `nodejs_packages` - boolean - Download nodejs node_modules.
 - `nodejs_path` - path - Where is 'package.json' located (need nodejs_packages).
+- `nodejs_package_manager` - string - Package manager to use for Node.js packages
+  (defaults to npm).
 - `sha_source`- string - Url to get the sha value.
 - `stable_version`- string - Regular expression to determine if it is a stable version.
 - `sync_version` - string - Category and ebuild with version to sync.

--- a/livecheck/constants.py
+++ b/livecheck/constants.py
@@ -8,7 +8,9 @@ from .utils import prefix_v
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
-__all__ = ('RSS_NS', 'SUBMODULES', 'TAG_NAME_FUNCTIONS')
+__all__ = ('PACKAGE_MANAGERS', 'RSS_NS', 'SUBMODULES', 'TAG_NAME_FUNCTIONS')
+
+PACKAGE_MANAGERS = frozenset({'npm', 'pnpm', 'yarn'})
 
 RSS_NS = {'': 'http://www.w3.org/2005/Atom'}
 """

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -16,6 +16,7 @@ from defusedxml import ElementTree as ET  # noqa: N817
 import click
 
 from .constants import (
+    PACKAGE_MANAGERS,
     SUBMODULES,
     TAG_NAME_FUNCTIONS,
 )
@@ -509,7 +510,9 @@ def do_main(  # noqa: C901, PLR0912, PLR0915
                     or (cp in settings.composer_packages and not check_composer_requirements())
                     or (cp in settings.maven_packages and not check_maven_requirements())
                     or (cp in settings.yarn_base_packages and not check_yarn_requirements())
-                    or (cp in settings.nodejs_packages and not check_nodejs_requirements())
+                    or (cp in settings.nodejs_packages
+                        and not check_nodejs_requirements(
+                            settings.get_package_manager(cp)))
                     or (cp in settings.gomodule_packages and not check_gomodule_requirements())):
                 log.warning('Update is not possible.')
                 return
@@ -581,7 +584,10 @@ def do_main(  # noqa: C901, PLR0912, PLR0915
             if cp in settings.maven_packages:
                 update_maven_ebuild(new_filename, settings.maven_path[cp], fetchlist)
             if cp in settings.nodejs_packages:
-                update_nodejs_ebuild(new_filename, settings.nodejs_path[cp], fetchlist)
+                update_nodejs_ebuild(new_filename,
+                                     settings.nodejs_path[cp],
+                                     fetchlist,
+                                     settings.get_package_manager(cp))
             if cp in settings.gomodule_packages:
                 update_gomodule_ebuild(new_filename, settings.gomodule_path[cp], fetchlist)
             if cp in settings.composer_packages:
@@ -617,6 +623,11 @@ def do_main(  # noqa: C901, PLR0912, PLR0915
               type=click.Path(file_okay=False, exists=True, resolve_path=True, path_type=Path))
 @click.option('-k', '--keep-old', is_flag=True, help='Keep old ebuild versions.')
 @click.option('-p', '--progress', is_flag=True, help='Enable progress logging.')
+@click.option('--package-manager',
+              type=click.Choice(sorted(PACKAGE_MANAGERS)),
+              default='npm',
+              show_default=True,
+              help='Package manager to use for Node.js packages.')
 @click.option('-W',
               '--working-dir',
               default='.',
@@ -637,7 +648,8 @@ def main(working_dir: Path,
          development: bool = False,
          git: bool = False,
          keep_old: bool = False,
-         progress: bool = False) -> None:
+         progress: bool = False,
+         package_manager: str = 'npm') -> None:
     """Update ebuilds to their latest versions."""  # noqa: DOC501
     setup_logging(debug=debug,
                   loggers={'livecheck': {
@@ -684,6 +696,7 @@ def main(working_dir: Path,
     settings.git_flag = git
     settings.keep_old_flag = keep_old
     settings.progress_flag = progress
+    settings.default_package_manager = package_manager
 
     package_names = sorted(package_names or [])
     cat = pkg = None

--- a/livecheck/settings.py
+++ b/livecheck/settings.py
@@ -9,6 +9,7 @@ import logging
 import re
 
 from . import utils
+from .constants import PACKAGE_MANAGERS
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -58,6 +59,7 @@ class LivecheckSettings:
     gomodule_path: dict[str, str] = field(default_factory=dict)
     nodejs_packages: dict[str, bool] = field(default_factory=dict)
     nodejs_path: dict[str, str] = field(default_factory=dict)
+    nodejs_package_managers: dict[str, str] = field(default_factory=dict)
     development: dict[str, bool] = field(default_factory=dict)
     composer_packages: dict[str, bool] = field(default_factory=dict)
     composer_path: dict[str, str] = field(default_factory=dict)
@@ -74,12 +76,17 @@ class LivecheckSettings:
     git_flag: bool = False
     keep_old_flag: bool = False
     progress_flag: bool = False
+    default_package_manager: str = 'npm'
     # Internal settings.
     restrict_version_process: str = ''
 
     def is_devel(self, catpkg: str) -> bool:
         """Check if the package is a development version."""
         return self.development.get(catpkg, self.development_flag)
+
+    def get_package_manager(self, catpkg: str) -> str:
+        """Return the package manager configured for a package."""
+        return self.nodejs_package_managers.get(catpkg, self.default_package_manager)
 
 
 class UnknownTransformationFunction(NameError):
@@ -115,6 +122,7 @@ def gather_settings(search_dir: Path) -> LivecheckSettings:  # noqa: C901, PLR09
     gomodule_path: dict[str, str] = {}
     nodejs_packages: dict[str, bool] = {}
     nodejs_path: dict[str, str] = {}
+    nodejs_package_managers: dict[str, str] = {}
     development: dict[str, bool] = {}
     composer_packages: dict[str, bool] = {}
     composer_path: dict[str, str] = {}
@@ -216,6 +224,14 @@ def gather_settings(search_dir: Path) -> LivecheckSettings:  # noqa: C901, PLR09
                 if settings_parsed.get('nodejs_path'):
                     check_instance(settings_parsed['nodejs_path'], 'nodejs_path', 'string', path)
                     nodejs_path[catpkg] = settings_parsed['nodejs_path']
+                if settings_parsed.get('nodejs_package_manager'):
+                    check_instance(settings_parsed['nodejs_package_manager'],
+                                   'nodejs_package_manager', 'string', path)
+                    manager = settings_parsed['nodejs_package_manager'].lower()
+                    if manager not in PACKAGE_MANAGERS:
+                        log.error('Invalid "nodejs_package_manager" in %s.', path)
+                    else:
+                        nodejs_package_managers[catpkg] = manager
             if 'development' in settings_parsed:
                 check_instance(settings_parsed['development'], 'development', 'bool', path)
                 development[catpkg] = settings_parsed['development']
@@ -264,7 +280,8 @@ def gather_settings(search_dir: Path) -> LivecheckSettings:  # noqa: C901, PLR09
         branches, custom_livechecks, dotnet_projects, golang_packages, type_packages,
         no_auto_update, sha_sources, transformations, yarn_base_packages, yarn_packages,
         jetbrains_packages, keep_old, gomodule_packages, gomodule_path, nodejs_packages,
-        nodejs_path, development, composer_packages, composer_path, maven_packages, maven_path,
+        nodejs_path, nodejs_package_managers, development, composer_packages, composer_path,
+        maven_packages, maven_path,
         regex_version, restrict_version, sync_version, stable_version)
 
 

--- a/livecheck/special/nodejs.py
+++ b/livecheck/special/nodejs.py
@@ -17,7 +17,7 @@ __all__ = ('check_nodejs_requirements', 'remove_nodejs_url', 'update_nodejs_ebui
 logger = logging.getLogger(__name__)
 
 PACKAGE_MANAGER_COMMANDS: dict[str, tuple[str, ...]] = {
-    'npm': ('npm', 'install', '--audit false', '--color false', '--progress false',
+    'npm': ('npm', 'install', '--no-audit', '--no-color', '--no-progress',
             '--ignore-scripts'),
     'yarn': ('yarn', 'install', '--ignore-scripts', '--silent', '--non-interactive'),
     'pnpm': ('pnpm', 'install', '--ignore-scripts', '--silent', '--color=false'),

--- a/livecheck/special/nodejs.py
+++ b/livecheck/special/nodejs.py
@@ -16,6 +16,13 @@ __all__ = ('check_nodejs_requirements', 'remove_nodejs_url', 'update_nodejs_ebui
 
 logger = logging.getLogger(__name__)
 
+PACKAGE_MANAGER_COMMANDS: dict[str, tuple[str, ...]] = {
+    'npm': ('npm', 'install', '--audit false', '--color false', '--progress false',
+            '--ignore-scripts'),
+    'yarn': ('yarn', 'install', '--ignore-scripts', '--silent', '--non-interactive'),
+    'pnpm': ('pnpm', 'install', '--ignore-scripts', '--silent', '--color=false'),
+}
+
 
 def remove_nodejs_url(ebuild_content: str) -> str:
     """Remove ``node_modules.tar.xz`` line from ebuild."""
@@ -23,27 +30,37 @@ def remove_nodejs_url(ebuild_content: str) -> str:
 
 
 def update_nodejs_ebuild(ebuild: str, path: str | None,
-                         fetchlist: Mapping[str, tuple[str, ...]]) -> None:
+                         fetchlist: Mapping[str, tuple[str, ...]],
+                         package_manager: str = 'npm') -> None:
     """Update a NodeJS-based ebuild."""
     package_path, temp_dir = search_ebuild(ebuild, 'package.json', path)
     if not package_path:
         return
 
+    manager = package_manager.lower()
+    command = PACKAGE_MANAGER_COMMANDS.get(manager)
+    if not command:
+        logger.error('Unsupported package manager: %s', package_manager)
+        return
+
     try:
-        sp.run(('npm', 'install', '--audit false', '--color false', '--progress false',
-                '--ignore-scripts'),
-               cwd=package_path,
-               check=True)
+        sp.run(command, cwd=package_path, check=True)
     except sp.CalledProcessError:
-        logger.exception("Error running 'npm install'.")
+        logger.exception("Error running '%s install'.", manager)
         return
 
     build_compress(temp_dir, package_path, 'node_modules', '-node_modules.tar.xz', fetchlist)
 
 
-def check_nodejs_requirements() -> bool:
-    """Check if npm is installed."""
-    if not check_program('npm', ['--version']):
-        logger.error('npm is not installed')
+def check_nodejs_requirements(package_manager: str = 'npm') -> bool:
+    """Check if the requested package manager is installed."""
+    manager = package_manager.lower()
+    command = PACKAGE_MANAGER_COMMANDS.get(manager)
+    if not command:
+        logger.error('Unsupported package manager: %s', package_manager)
+        return False
+
+    if not check_program(command[0], ['--version']):
+        logger.error('%s is not installed', command[0])
         return False
     return True

--- a/man/livecheck.1
+++ b/man/livecheck.1
@@ -89,6 +89,11 @@ Enable progress logging.
 .UNINDENT
 .INDENT 0.0
 .TP
+.B \-\-package\-manager [npm|pnpm|yarn]
+Package manager to use for Node.js packages.
+.UNINDENT
+.INDENT 0.0
+.TP
 .B \-W, \-\-working\-dir <working_dir>
 Working directory. Should be a port tree root.
 .UNINDENT

--- a/tests/special/test_nodejs.py
+++ b/tests/special/test_nodejs.py
@@ -99,14 +99,43 @@ def test_update_nodejs_ebuild_npm_install_fails(mocker: MockerFixture) -> None:
     assert mock_logger.exception.call_count == 1
 
 
+def test_update_nodejs_ebuild_other_package_manager(mocker: MockerFixture) -> None:
+    mock_search_ebuild = mocker.patch('livecheck.special.nodejs.search_ebuild')
+    mock_run = mocker.patch('livecheck.special.nodejs.sp.run')
+    mock_build_compress = mocker.patch('livecheck.special.nodejs.build_compress')
+
+    mock_search_ebuild.return_value = ('/tmp/pkg', '/tmp/tmpdir')
+
+    update_nodejs_ebuild('dummy.ebuild', None, {}, package_manager='yarn')
+
+    mock_run.assert_called_once_with(('yarn', 'install', '--ignore-scripts', '--silent',
+                                      '--non-interactive'),
+                                     cwd='/tmp/pkg',
+                                     check=True)
+    mock_build_compress.assert_called_once()
+
+
+def test_update_nodejs_ebuild_invalid_package_manager(mocker: MockerFixture) -> None:
+    mock_search_ebuild = mocker.patch('livecheck.special.nodejs.search_ebuild')
+    mock_run = mocker.patch('livecheck.special.nodejs.sp.run')
+    mock_logger = mocker.patch('livecheck.special.nodejs.logger')
+
+    mock_search_ebuild.return_value = ('/tmp/pkg', '/tmp/tmpdir')
+
+    update_nodejs_ebuild('dummy.ebuild', None, {}, package_manager='invalid')
+
+    mock_run.assert_not_called()
+    mock_logger.error.assert_called_once_with('Unsupported package manager: %s', 'invalid')
+
+
 def test_check_nodejs_requirements_success(mocker: MockerFixture) -> None:
     mock_check_program = mocker.patch('livecheck.special.nodejs.check_program')
     mock_logger = mocker.patch('livecheck.special.nodejs.logger')
     mock_check_program.return_value = True
 
-    result = check_nodejs_requirements()
+    result = check_nodejs_requirements('pnpm')
 
-    mock_check_program.assert_called_once_with('npm', ['--version'])
+    mock_check_program.assert_called_once_with('pnpm', ['--version'])
     assert result is True
     mock_logger.error.assert_not_called()
 
@@ -120,4 +149,15 @@ def test_check_nodejs_requirements_failure(mocker: MockerFixture) -> None:
 
     mock_check_program.assert_called_once_with('npm', ['--version'])
     assert result is False
-    mock_logger.error.assert_called_once_with('npm is not installed')
+    mock_logger.error.assert_called_once_with('%s is not installed', 'npm')
+
+
+def test_check_nodejs_requirements_invalid_manager(mocker: MockerFixture) -> None:
+    mock_check_program = mocker.patch('livecheck.special.nodejs.check_program')
+    mock_logger = mocker.patch('livecheck.special.nodejs.logger')
+
+    result = check_nodejs_requirements('invalid')
+
+    assert result is False
+    mock_check_program.assert_not_called()
+    mock_logger.error.assert_called_once_with('Unsupported package manager: %s', 'invalid')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,6 +98,11 @@ def mock_settings(mocker: MockerFixture) -> Any:
     settings.keep_old_flag = False
     settings.no_auto_update = set()
     settings.nodejs_packages = set()
+    settings.nodejs_package_managers = {}
+    settings.default_package_manager = 'npm'
+    settings.get_package_manager = mocker.Mock(
+        side_effect=lambda cp: settings.nodejs_package_managers.get(cp,
+                                                                    settings.default_package_manager))
     settings.maven_packages = set()
     settings.progress_flag = False
     settings.sha_sources = {}
@@ -655,7 +660,61 @@ def test_do_main_nodejs_packages(mocker: MockerFixture, tmp_path: Path,
             top_hash=top_hash,
             url=url)
     mock_update_nodejs_ebuild.assert_called_once_with(
-        f'{search_dir}/{cat}/{pkg}/{pkg}-{last_version}.ebuild', mocker.ANY, {})
+        f'{search_dir}/{cat}/{pkg}/{pkg}-{last_version}.ebuild', mocker.ANY, {}, 'npm')
+    mock_write.assert_called_once_with('abcdef1', encoding='utf-8')
+
+
+def test_do_main_nodejs_packages_custom_manager(mocker: MockerFixture, tmp_path: Path,
+                                                mock_settings: Mock) -> None:
+    cat = 'cat'
+    pkg = 'pkg'
+    ebuild_version = '1.0.0'
+    last_version = '1.0.1'
+    top_hash = 'abcdef1'
+    hash_date = ''
+    url = 'https://example.com'
+    hook_dir = None
+    search_dir = tmp_path
+    cp = f'{cat}/{pkg}'
+    ebuild_path = tmp_path / f'{cat}/{pkg}/{pkg}-1.0.0.ebuild'
+    ebuild_path.parent.mkdir(parents=True)
+    ebuild_path.write_text('SHA="1234567"\n', encoding='utf-8')
+    mock_settings.auto_update_flag = True
+    mock_settings.nodejs_packages = {cp}
+    mock_settings.nodejs_package_managers = {cp: 'pnpm'}
+    mock_settings.get_package_manager.side_effect = (
+        lambda name: mock_settings.nodejs_package_managers.get(name, 'npm'))
+    mocker.patch('livecheck.main.get_old_sha', return_value='1234567')
+    mocker.patch('livecheck.main.replace_date_in_ebuild', side_effect=lambda v, _, __: v)
+    mocker.patch('livecheck.main.remove_leading_zeros', side_effect=lambda v: v)
+    mocker.patch('livecheck.main.compare_versions', return_value=True)
+    mocker.patch('livecheck.main.catpkg_catpkgsplit', return_value=(cp, cat, pkg, last_version))
+    mocker.patch('livecheck.main.catpkgsplit2', return_value=(cat, pkg, last_version, 'r0'))
+    mocker.patch('livecheck.main.str_version', side_effect=lambda v, _: v)
+    mocker.patch('livecheck.main.digest_ebuild', return_value=True)
+    mocker.patch('livecheck.main.P.getFetchMap', return_value={})
+    mocker.patch('livecheck.main.is_sha', return_value=True)
+    mocker.patch('livecheck.main.process_submodules', side_effect=lambda *a, **_: a[1])
+    mocker.patch('livecheck.main.execute_hooks')
+    mocker.patch('livecheck.main.Path.read_text', return_value='SHA="1234567"\n')
+    mock_write = mocker.patch('livecheck.main.Path.write_text')
+    mocker.patch('livecheck.main.P.aux_get', return_value=['https://homepage'])
+    mocker.patch('livecheck.main.sp.run', return_value=mocker.Mock(returncode=0))
+    mock_update_nodejs_ebuild = mocker.patch('livecheck.main.update_nodejs_ebuild')
+
+    do_main(cat=cat,
+            ebuild_version=ebuild_version,
+            hash_date=hash_date,
+            hook_dir=hook_dir,
+            last_version=last_version,
+            pkg=pkg,
+            search_dir=search_dir,
+            settings=mock_settings,
+            top_hash=top_hash,
+            url=url)
+
+    mock_update_nodejs_ebuild.assert_called_once_with(
+        f'{search_dir}/{cat}/{pkg}/{pkg}-{last_version}.ebuild', mocker.ANY, {}, 'pnpm')
     mock_write.assert_called_once_with('abcdef1', encoding='utf-8')
 
 


### PR DESCRIPTION
## Summary
- add a `--package-manager` CLI option defaulting to npm for Node.js updates
- allow per-package overrides via new `nodejs_package_manager` settings and helper
- update Node.js tooling to handle yarn/pnpm, with documentation and tests adjusted accordingly

## Testing
- `PYTHONPATH=. pytest tests/special/test_nodejs.py tests/test_settings.py tests/test_main.py` *(fails: missing portage module)*

------
https://chatgpt.com/codex/tasks/task_e_68d70a644bf0832eba3814427c6e3d83